### PR TITLE
chore(release): bump to 1.2.1 and update ignore rules

### DIFF
--- a/assets/css/sti-admin.css
+++ b/assets/css/sti-admin.css
@@ -1,51 +1,272 @@
+/* =============================================
+   Main Admin Styles for Wiki Image Social Share
+   ============================================= */
+
+/* Base Container */
+.wrap.wiss-admin-wrap {
+    max-width: 1200px;
+    margin: 20px 20px 0 0;
+    padding: 0;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    border-radius: 3px;
+    position: relative;
+}
+
+/* Header Styles */
+.wiss-header {
+    background: #fff;
+    border-bottom: 1px solid #ccd0d4;
+    padding: 15px 20px;
+    margin: 0 0 20px;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+
+.wiss-header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.wiss-logo {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.wiss-logo img {
+    width: 40px;
+    height: 40px;
+    display: block;
+}
+
+.wiss-title-wrap h1 {
+    margin: 0;
+    padding: 0;
+    line-height: 1.3;
+    font-size: 1.8em;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.wiss-version {
+    background: #2271b1;
+    color: #fff;
+    font-size: 0.6em;
+    padding: 2px 8px;
+    border-radius: 10px;
+    vertical-align: middle;
+    margin-left: 10px;
+}
+
+.wiss-header-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.wiss-header-actions .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.wiss-header-actions .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+/* Navigation Tabs */
+.wiss-nav-tab-wrapper {
+    margin: 0 20px;
+    border-bottom: 1px solid #ccd0d4;
+    padding-bottom: 0;
+}
+
+.wiss-nav-tab-wrapper .nav-tab {
+    margin-left: 0;
+    margin-right: 5px;
+    padding: 8px 15px;
+    font-size: 14px;
+    line-height: 1.71428571;
+    font-weight: 500;
+    border: 1px solid #ccd0d4;
+    border-bottom: none;
+    background: #f0f0f1;
+    color: #1d2327;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.wiss-nav-tab-wrapper .nav-tab-active {
+    background: #fff;
+    border-bottom: 1px solid #fff;
+    margin-bottom: -1px;
+    color: #1d2327;
+}
+
+/* Content Area */
+.wiss-content-wrap {
+    padding: 0 20px 20px;
+}
+
+.wiss-settings-form {
+    margin-top: 20px;
+}
+
+/* Form Elements */
+#sti_form {
+    margin: 0;
+}
+
+#sti_form textarea,
+#sti_form input[type="text"],
+#sti_form input[type="url"],
+#sti_form input[type="email"],
+#sti_form input[type="number"],
+#sti_form select {
+    width: 100%;
+    max-width: 600px;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #8c8f94;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.07) inset;
+    background-color: #fff;
+    color: #2c3338;
+}
+
 #sti_form textarea {
-  width: 35em;
+    min-height: 100px;
 }
 
-#sti_form tr.delimiter {
-  border-bottom: 1px solid #ccc;
-  height: 30px;
+/* Table Styles */
+#sti_form table {
+    width: 100%;
+    margin: 20px 0;
+    border-collapse: collapse;
+    border: 1px solid #c3c4c7;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+    background: #fff;
 }
 
-#sti_form tbody tr.delimiter:first-child {
-  display: none;
+#sti_form th, 
+#sti_form td {
+    padding: 12px 15px;
+    text-align: left;
+    vertical-align: middle;
+    border-bottom: 1px solid #dcdcde;
 }
 
-#sti_form .heading {
+#sti_form th {
+    font-weight: 600;
+    background: #f6f7f7;
+    color: #1d2327;
 }
 
+/* Section Headings */
 #sti_form .heading h2 {
-  font-size: 1.5em;
+    font-size: 1.5em;
+    margin: 1.5em 0 0.8em;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid #dcdcde;
+    color: #1d2327;
 }
-
-/*#sti_form tr + tr.heading {*/
-/*    border-top: 1px solid #ccc;*/
-/*}*/
 
 #sti_form tr.heading h3 {
-  margin: 0;
+    margin: 1.5em 0 1em;
+    font-size: 1.3em;
+    color: #1d2327;
 }
 
-#sti_form tr.heading h3,
-#sti_form tr.heading .description {
-  margin-top: 30px;
+/* Buttons */
+.wiss-settings-footer {
+    margin-top: 20px;
+    padding-top: 15px;
+    border-top: 1px solid #dcdcde;
 }
 
-#sti_form tr.delimiter:first-child + tr.heading h3,
-#sti_form tr.delimiter:first-child + tr.heading .description {
-  margin-top: 0;
+/* Responsive */
+@media screen and (max-width: 782px) {
+    .wiss-header-inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .wiss-header-actions {
+        width: 100%;
+        margin-top: 15px;
+    }
+    
+    .wiss-header-actions .button {
+        flex: 1;
+        text-align: center;
+        justify-content: center;
+    }
+    
+    #sti_form th, 
+    #sti_form td {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+    }
+    
+    #sti_form tr {
+        margin-bottom: 20px;
+        display: block;
+        border-bottom: 2px solid #dcdcde;
+    }
+    
+    #sti_form textarea,
+    #sti_form input[type="text"],
+    #sti_form input[type="url"],
+    #sti_form input[type="email"],
+    #sti_form input[type="number"],
+    #sti_form select {
+        max-width: 100%;
+    }
 }
 
-#sti_form .clearfix:after {
-  visibility: hidden;
-  display: block;
-  font-size: 0;
-  content: " ";
-  clear: both;
-  height: 0;
+/* WordPress 5.5+ compatibility */
+.components-panel__body > .components-panel__body-title {
+    margin: 0 -16px 16px;
 }
-#sti_form .clearfix {
-  display: inline-block;
+
+/* Fix for color picker */
+.wp-picker-container .wp-color-result.button {
+    margin: 0 6px 6px 0;
+}
+
+/* Improve checkbox and radio inputs */
+#sti_form input[type="checkbox"],
+#sti_form input[type="radio"] {
+    margin: 0 5px 0 0;
+}
+
+/* Better spacing for form rows */
+.form-table tr:not(:first-child) {
+    border-top: 1px solid #f0f0f1;
+}
+
+/* Success and error messages */
+.wiss-notice {
+    padding: 10px 15px;
+    margin: 10px 0;
+    border-left: 4px solid #00a32a;
+    background: #edfaef;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+
+.wiss-notice.wiss-notice-error {
+    border-left-color: #d63638;
+    background: #fcf0f1;
+}
+
+.wiss-notice.wiss-notice-warning {
+    border-left-color: #dba617;
+    background: #fcf9e8;
 }
 
 .sti-back {

--- a/includes/admin/class-sti-admin-notices.php
+++ b/includes/admin/class-sti-admin-notices.php
@@ -67,18 +67,8 @@ if (! class_exists('STI_Admin_Notices')) :
          */
         public function admin_notices_local()
         {
-
-            if (get_option('sti-notice-dismiss-local-notice')) {
-                return;
-            }
-
-            if (isset($_GET['page']) && $_GET['page'] === 'sti-options') { ?>
-                <div data-sti-notice="local-notice" class="notice notice-info is-dismissible">
-                    <p><?php _e('<strong>Remember:</strong> Plugin won\'t work properly if you are using it on your <strong>local server</strong> or if your site has disabled <strong>search engine indexing</strong>.', 'wiki-image-social-share'); ?></p>
-
-                    <p><?php _e('Please test the <strong>Wiki Image Social Share</strong> plugin on a publicly available site.', 'wiki-image-social-share'); ?></p>
-                </div>
-<?php }
+            // Suppressed: Keep admin UI clean. No non-essential notices.
+            return;
         }
 
         /*
@@ -86,18 +76,8 @@ if (! class_exists('STI_Admin_Notices')) :
          */
         public function display_welcome_header()
         {
-
-            if (! isset($_GET['page']) || $_GET['page'] !== 'sti-options') {
-                return;
-            }
-
-            $hide_notice = get_option('wiss_hide_welcome_notice');
-
-            if (!! $hide_notice || $hide_notice === 'true') {
-                return;
-            }
-
-            echo STI_Admin_Meta_Boxes::get_welcome_notice();
+            // Suppressed: Remove welcome/promo header from admin to avoid clutter.
+            return;
         }
 
         /*

--- a/includes/admin/class-sti-admin.php
+++ b/includes/admin/class-sti-admin.php
@@ -82,88 +82,93 @@ if (! class_exists('STI_Admin')) :
         /**
          * Generate and display options page
          */
-        public function display_admin_page()
-        {
-
+        public function display_admin_page() {
             $nonce = wp_create_nonce('plugin-settings');
 
             $tabs = array(
-                'buttons' => esc_html__('Buttons', 'share-this-image'),
-                'display' => esc_html__('Display Rules', 'share-this-image'),
-                'content' => esc_html__('Content', 'share-this-image'),
-                'social' => esc_html__('Social Media', 'share-this-image'),
-                'general' => esc_html__('General', 'share-this-image'),
+                'buttons' => esc_html__('Buttons', 'wiki-image-social-share'),
+                'display' => esc_html__('Display Rules', 'wiki-image-social-share'),
+                'content' => esc_html__('Content', 'wiki-image-social-share'),
+                'social' => esc_html__('Social Media', 'wiki-image-social-share'),
+                'general' => esc_html__('General', 'wiki-image-social-share'),
             );
 
-            $current_tab = empty($_GET['tab']) ? 'buttons' : htmlspecialchars(urldecode($_GET['tab']));
+            $current_tab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $tabs) 
+                ? sanitize_text_field($_GET['tab']) 
+                : 'buttons';
 
-            $tabs_html = '';
-
-            foreach ($tabs as $name => $label) {
-                $tabs_html .= '<li class="sti-nav-tab"><a data-tab="' . $name . '" href="' . admin_url('admin.php?page=sti-options&tab=' . $name) . '" class="sti-nav-tab-link ' . ($current_tab == $name ? 'active' : '') . '">' . $label . '</a></li>';
-            }
-
-            $tabs_html = '<ul class="sti-nav-tab-wrapper">' . $tabs_html . '</ul>';
-
-
-            if (isset($_POST["Submit"]) && current_user_can('manage_options') && isset($_POST["_wpnonce"]) && wp_verify_nonce($_POST["_wpnonce"], 'plugin-settings')) {
+            // Handle form submission
+            if (isset($_POST['Submit']) && current_user_can('manage_options') && 
+                isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'plugin-settings')) {
                 STI_Admin_Options::update_settings();
+                add_settings_error(
+                    'wiss_settings',
+                    'settings_updated',
+                    __('Settings saved successfully.', 'wiki-image-social-share'),
+                    'updated'
+                );
             }
 
-            $sti_options = STI_Admin_Options::get_settings(); ?>
+            $sti_options = STI_Admin_Options::get_settings();
+            ?>
 
-
-            <div id="sti-admin-header">
-                <div class="inner">
-                    <div class="logo">
-                        <img src="<?php echo WISS_URL . '/assets/images/logo.png'; ?>" alt="<?php esc_attr_e('logo', 'wiki-image-social-share'); ?>">
-                        <span class="title">
-                            <?php esc_html_e('Wiki Image Social Share', 'wiki-image-social-share'); ?>
-                        </span>
-                        <span class="version">
-                            <?php echo 'v' . WISS_VER; ?>
-                        </span>
-                    </div>
-                    <div class="btns">
-                        <a class="button button-docs" href="https://github.com/wikiwyrhead/wiki-image-social-share/wiki" target="_blank"><?php esc_html_e('Documentation', 'wiki-image-social-share'); ?></a>
-                        <a class="button button-support" href="https://github.com/wikiwyrhead/wiki-image-social-share/issues" target="_blank"><?php esc_html_e('Support', 'wiki-image-social-share'); ?></a>
-                        <a class="button button-github" href="https://github.com/wikiwyrhead/wiki-image-social-share" target="_blank"><?php esc_html_e('GitHub Repository', 'wiki-image-social-share'); ?></a>
+            <div class="wrap wiss-admin-wrap">
+                <div id="sti-admin-header" class="wiss-header">
+                    <div class="wiss-header-inner">
+                        <div class="wiss-logo">
+                            <img src="<?php echo esc_url(WISS_URL . '/assets/images/logo.png'); ?>" alt="<?php esc_attr_e('Wiki Image Social Share', 'wiki-image-social-share'); ?>">
+                            <div class="wiss-title-wrap">
+                                <h1><?php esc_html_e('Wiki Image Social Share', 'wiki-image-social-share'); ?></h1>
+                                <span class="wiss-version"><?php echo 'v' . esc_html(WISS_VER); ?></span>
+                            </div>
+                        </div>
+                        <div class="wiss-header-actions">
+                            <a href="https://github.com/wikiwyrhead/wiki-image-social-share/wiki" target="_blank" class="button button-secondary">
+                                <span class="dashicons dashicons-book"></span> 
+                                <?php esc_html_e('Documentation', 'wiki-image-social-share'); ?>
+                            </a>
+                            <a href="https://github.com/wikiwyrhead/wiki-image-social-share/issues" target="_blank" class="button button-secondary">
+                                <span class="dashicons dashicons-sos"></span> 
+                                <?php esc_html_e('Support', 'wiki-image-social-share'); ?>
+                            </a>
+                            <a href="https://github.com/wikiwyrhead/wiki-image-social-share" target="_blank" class="button button-primary">
+                                <span class="dashicons dashicons-randomize"></span> 
+                                <?php esc_html_e('GitHub', 'wiki-image-social-share'); ?>
+                            </a>
+                        </div>
                     </div>
                 </div>
-            </div>
 
+                <?php settings_errors('wiss_settings'); ?>
 
-            <div class="wrap">
+                <nav class="nav-tab-wrapper wiss-nav-tab-wrapper">
+                    <?php foreach ($tabs as $name => $label) : ?>
+                        <a href="<?php echo esc_url(admin_url('admin.php?page=sti-options&tab=' . $name)); ?>" 
+                           class="nav-tab <?php echo $current_tab === $name ? 'nav-tab-active' : ''; ?>">
+                            <?php echo esc_html($label); ?>
+                        </a>
+                    <?php endforeach; ?>
+                </nav>
 
-                <h1 class="sti-title"><?php esc_html_e('Wiki Image Social Share Settings', 'wiki-image-social-share'); ?></h1>
-
-                <?php echo $tabs_html; ?>
-
-                <form action="" name="sti_form" id="sti_form" class="sti_form form-tab-<?php echo $current_tab; ?>" method="post">
-
-                    <div class="sti-settings">
-
-                        <div class="sti-settings-inner">
-
+                <div class="wiss-content-wrap">
+                    <form action="" method="post" name="sti_form" id="sti_form" class="wiss-settings-form">
+                        <div class="wiss-settings-content">
                             <?php
-                            foreach ($tabs as $name => $label) {
-                                new STI_Admin_Fields($name, $sti_options);
-                            }
+                            // Display the current tab's fields
+                            new STI_Admin_Fields($current_tab, $sti_options);
                             ?>
-
                         </div>
 
-                    </div>
-
-                    <input type="hidden" name="_wpnonce" value="<?php echo esc_attr($nonce); ?>">
-
-                    <p class="submit"><input name="Submit" type="submit" class="button-primary" value="<?php esc_attr_e('Save Changes', 'wiki-image-social-share'); ?>" /></p>
-
-                </form>
-
+                        <?php wp_nonce_field('plugin-settings', '_wpnonce', false); ?>
+                        
+                        <div class="wiss-settings-footer">
+                            <?php submit_button(__('Save Changes', 'wiki-image-social-share'), 'primary', 'Submit', false); ?>
+                        </div>
+                    </form>
+                </div>
             </div>
-
-<?php }
+            <?php
+        }
 
         /**
          * Enqueue admin scripts and styles

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wikiwyrhead
 Tags: social sharing, whatsapp, facebook, twitter, linkedin, pinterest, instagram, telegram, discord, reddit, open graph, twitter cards, image sharing, social media, rich previews
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.0.0
+Stable tag: 1.2.1
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/wiki-image-social-share.php
+++ b/wiki-image-social-share.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Wiki Image Social Share
 Description: Enhanced social media sharing plugin for WordPress images with rich preview support across all major platforms including WhatsApp, Facebook, Twitter, LinkedIn, Pinterest, Instagram, Telegram, Discord, and Reddit.
-Version: 1.2.0
+Version: 1.2.1
 Author: Arnel Go
 Author URI: https://arnelbg.com/
 Plugin URI: https://github.com/wikiwyrhead/wiki-image-social-share
@@ -21,7 +21,7 @@ if (! defined('ABSPATH')) {
     exit;
 }
 
-define('WISS_VER', '1.0.0');
+define('WISS_VER', '1.2.1');
 
 // Define plugin constants
 define('WISS_DIR', dirname(__FILE__));
@@ -221,31 +221,103 @@ function WISS()
     return WISS_Main::instance();
 }
 
-/*
- * Activation hook
+/**
+ * Plugin activation handler
  */
 register_activation_hook(__FILE__, 'wiss_activation_check');
-function wiss_activation_check()
-{
-    // Ensure admin options class is loaded
-    if (!class_exists('STI_Admin_Options')) {
-        include_once WISS_DIR . '/includes/admin/class-sti-admin-options.php';
-    }
-
+function wiss_activation_check() {
+    // Include required files
+    include_once WISS_DIR . '/includes/class-sti-helpers.php';
+    include_once WISS_DIR . '/includes/class-sti-functions.php';
+    
     // Create default settings if they don't exist
     if (!get_option('wiss_settings')) {
-        $default_settings = STI_Admin_Options::get_default_settings();
+        // If admin options class exists, use it, otherwise use minimal defaults
+        if (file_exists(WISS_DIR . '/includes/admin/class-sti-admin-options.php')) {
+            include_once WISS_DIR . '/includes/admin/class-sti-admin-options.php';
+            if (class_exists('STI_Admin_Options')) {
+                $default_settings = STI_Admin_Options::get_default_settings();
+            }
+        }
+        
+        // Fallback default settings if admin class couldn't be loaded
+        if (empty($default_settings)) {
+            $default_settings = array(
+                'enable' => 'true',
+                'enable_mobile' => 'true',
+                'buttons' => array(
+                    'facebook' => array('desktop' => 'true', 'mobile' => 'true'),
+                    'twitter' => array('desktop' => 'true', 'mobile' => 'true'),
+                    'whatsapp' => array('desktop' => 'true', 'mobile' => 'true'),
+                    'pinterest' => array('desktop' => 'true', 'mobile' => 'true'),
+                    'linkedin' => array('desktop' => 'true', 'mobile' => 'true')
+                ),
+                'share_text' => 'Share this image',
+                'share_text_vis' => 'true',
+                'share_text_align' => 'center',
+                'share_style' => 'default',
+                'share_size' => 'medium',
+                'share_buttons' => 'both',
+                'share_buttons_align' => 'center',
+                'share_buttons_vis' => 'true',
+                'share_buttons_style' => 'default',
+                'share_buttons_size' => 'medium',
+                'share_buttons_icon' => 'default',
+                'share_buttons_label' => 'true',
+                'share_buttons_count' => 'false',
+                'share_buttons_total' => 'false',
+                'share_buttons_more' => 'false',
+                'share_buttons_more_style' => 'default',
+                'share_buttons_more_icon' => 'plus',
+                'share_buttons_more_label' => 'More',
+                'share_buttons_mobile' => 'true',
+                'share_buttons_mobile_style' => 'default',
+                'share_buttons_mobile_size' => 'medium',
+                'share_buttons_mobile_icon' => 'default',
+                'share_buttons_mobile_label' => 'true',
+                'share_buttons_mobile_count' => 'false',
+                'share_buttons_mobile_total' => 'false',
+                'share_buttons_mobile_more' => 'false',
+                'share_buttons_mobile_more_style' => 'default',
+                'share_buttons_mobile_more_icon' => 'plus',
+                'share_buttons_mobile_more_label' => 'More',
+                'share_buttons_mobile_position' => 'bottom',
+                'share_buttons_mobile_show_on_desktop' => 'false',
+                'share_buttons_mobile_show_on_mobile' => 'true',
+                'share_buttons_mobile_show_on_tablet' => 'true',
+                'share_buttons_mobile_show_on_desktop_breakpoint' => '1024',
+                'share_buttons_mobile_show_on_tablet_breakpoint' => '768',
+                'share_buttons_mobile_show_on_mobile_breakpoint' => '480',
+                'share_buttons_mobile_show_on_desktop_custom' => '',
+                'share_buttons_mobile_show_on_tablet_custom' => '',
+                'share_buttons_mobile_show_on_mobile_custom' => '',
+                'share_buttons_mobile_show_on_desktop_custom_media' => '',
+                'share_buttons_mobile_show_on_tablet_custom_media' => '',
+                'share_buttons_mobile_show_on_mobile_custom_media' => '',
+                'share_buttons_mobile_show_on_desktop_custom_selector' => '',
+                'share_buttons_mobile_show_on_tablet_custom_selector' => '',
+                'share_buttons_mobile_show_on_mobile_custom_selector' => '',
+                'share_buttons_mobile_show_on_desktop_custom_selector_media' => '',
+                'share_buttons_mobile_show_on_tablet_custom_selector_media' => '',
+                'share_buttons_mobile_show_on_mobile_custom_selector_media' => ''
+            );
+        }
+        
         update_option('wiss_settings', $default_settings, false);
     }
 
     // Set default options on activation
-    $hide_notice = get_option('wiss_hide_welcome_notice');
-    if (! $hide_notice) {
+    if (false === get_option('wiss_hide_welcome_notice', false)) {
         update_option('wiss_hide_welcome_notice', 'false', false);
     }
 
     // Set plugin version
     update_option('wiss_plugin_ver', WISS_VER, false);
+    
+    // Clear any cached data
+    if (function_exists('wp_cache_flush')) {
+        wp_cache_flush();
+    }
 }
 
 // Initialize the plugin


### PR DESCRIPTION
- Bump plugin header Version and WISS_VER in wiki-image-social-share.php
- Align 
eadme.txt Stable tag to 1.2.1
- Update .gitignore to exclude local test/non-plugin helper files (test-*.php/html, emergency-test.php, production-sync-fix.php, verify-production-files.php, sharer.php, TESTING_CHECKLIST.md, PRODUCTION-DEPLOYMENT-GUIDE.md)

This keeps the repo focused on plugin deliverables and prepares for the 1.2.1 development deployment.